### PR TITLE
Fix layout when using description in children list

### DIFF
--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -49,21 +49,29 @@
 
 					{{(printf "<h%d>" $numn)|safeHTML}}
 					<a href="{{.RelPermalink}}" >{{ .Title }}</a>
+					{{if $.description}}
+						{{if .Description}}
+							<p>{{.Description}}</p>
+						{{else}}
+							<p>{{.Summary}}</p>
+						{{end}}
+					{{end}}
 					{{(printf "</h%d>" $numn)|safeHTML}}
 
 				{{else}}
 					{{(printf "<%s>" $.style)|safeHTML}}
 					<a href="{{.RelPermalink}}" >{{ .Title }}</a>
+					{{if $.description}}
+						{{if .Description}}
+							<p>{{.Description}}</p>
+						{{else}}
+							<p>{{.Summary}}</p>
+						{{end}}
+					{{end}}
 					{{(printf "</%s>" $.style)|safeHTML}}
 				{{end}}
 
-				{{if $.description}}
-					{{if .Description}}
-						<p>{{.Description}}</p>
-					{{else}}
-						<p>{{.Summary}}</p>
-					{{end}}
-				{{end}}
+
 			{{end}}
 			{{ if lt $.count $.depth}}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The layout is broken when using children list with description, because the `<p>`'s were outside the `<li>`'s that were supposed to be holding them (see screenshots).

Before:
<img width="1035" alt="Screenshot 2021-08-10 at 15 07 58" src="https://user-images.githubusercontent.com/1009343/128872837-d3510c58-7da1-49a4-aae8-c12c265b3a1d.png">

After:
<img width="1029" alt="Screenshot 2021-08-10 at 15 08 06" src="https://user-images.githubusercontent.com/1009343/128872869-984d9204-4bcd-4222-bba6-2ae3e09f07cb.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
