### PR TITLE
Add version meta to every page

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -9,3 +9,7 @@
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}">
 {{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
+{{ if .Site.Params.docSearch }}
+  {{- $currentSection := .FirstSection.Params.versionId | default .Site.Params.versions.current -}}
+  <meta name="docsearch:version" content="{{ $currentSection }}" />
+{{- end }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adding a [meta tag as described by docsearch docs](https://docsearch.algolia.com/docs/required-configuration#introduce-global-information-as-meta-tags) might help docsearch figure out which version content belongs to.
