### PR TITLE
Only load mermaid when the page specifically enables it

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,11 +21,13 @@
     <script src="{{"js/hugo-learn.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
     {{$built := resources.Get "js/theme.js" | js.Build "main.js" }}
     <script src="{{ $built.RelPermalink }}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
+    {{ if .Params.useMermaid -}}
     <link href="{{"mermaid/mermaid.css" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet" />
     <script src="{{"mermaid/mermaid.js" | relURL}}{{ if not .Site.Params.disableAssetsBusting }}?{{ now.Unix }}{{ end }}"></script>
     <script>
         mermaid.initialize({ startOnLoad: true });
     </script>
+    {{- end }}
     {{ partial "docsearch.html" . }}
     {{ partial "custom-footer.html" . }}
   </body>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Only load [mermaid](https://mermaid-js.github.io/) when the page specifically enables it in its front matter using `useMermaid: true`. This will shave 487 KB from the initial page load on almost all pages.

<img width="686" alt="Screenshot 2021-08-24 at 17 25 33" src="https://user-images.githubusercontent.com/1009343/130644837-ab3285d7-a7a7-400e-9415-6754691f5871.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
