### PR TITLE
Add majorversion shortcode

### DIFF
--- a/layouts/shortcodes/majorversion.html
+++ b/layouts/shortcodes/majorversion.html
@@ -1,0 +1,1 @@
+{{ print $.Page.FirstSection.Params.Versionid }}

--- a/layouts/shortcodes/majorversion.html
+++ b/layouts/shortcodes/majorversion.html
@@ -1,1 +1,1 @@
-{{ print $.Page.FirstSection.Params.Versionid }}
+{{- print $.Page.FirstSection.Params.Versionid -}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | See below
| Type?             | new feature
| Fixed ticket?     | Fixes https://github.com/PrestaShop/docs/issues/1125


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

### Description

We need to replace "PrestaShop 1.7" by "PrestaShop 8.0" everywhere in 8.x.

But one day there will be a PrestaShop 9 or a PrestaShop 10. We might avoid to redo the big "find and replace" by using a Hugo variable that contains the version number. This needs to be done using a [shortcode](https://gohugo.io/templates/shortcode-templates/).

```
// a new hugo shortcode
{{ print $.Page.FirstSection.Params.Versionid }}
```

The shortcode I submit here allows to print the major version number contained in the [_readme.md](https://github.com/PrestaShop/docs/blob/1.7.x/_index.md) at the root of the docs repository.

After this shortcode has been merged into this repository, we can start using it like this

```
// current docs src
This document describes the faceted search
architecture that is being implemented in PrestaShop 1.7.
```

🔽 

```
// new content using the shortcode
This document describes the faceted search
architecture that is being implemented in PrestaShop {{% majorversion %}}.
```
The above markdown will output `This document describes the faceted search architecture that is being implemented in PrestaShop 8.` on PrestaShop 8.x documentation.

One day, when we publish the documentation for 9.x or 10.x, if we change the Versionid it will output the right version automatically.