### PR TITLE
Fix indexing pages with canonicals

### DIFF
--- a/layouts/partials/search-script.html
+++ b/layouts/partials/search-script.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.2.1"></script>
   <script type="text/javascript">
     docsearch({
+      ignoreCanonicalTo: true,
       appId: '{{ .Site.Params.docSearch.appId }}',
       apiKey: '{{ .Site.Params.docSearch.apiKey }}',
       indexName: '{{ .Site.Params.docSearch.indexName }}',


### PR DESCRIPTION
This should allow us to crawl pages properly, even with the canonical URL specified.