### PR TITLE
Display author and date of last commit on footer of pages

### DIFF
--- a/assets/sass/_theme.scss
+++ b/assets/sass/_theme.scss
@@ -1236,3 +1236,10 @@ dd {
     margin-top: 1rem;
   }
 }
+
+footer {
+    div.git-info {
+        margin-top: 10px;
+        margin-bottom: 10px;
+    }
+}

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -24,3 +24,6 @@ other = "More"
 
 [Expand-title]
 other = "Expand me..."
+
+[Seen-Mistake-Improve]
+other = "Seen a mistake? want to improve the documentation?"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -24,3 +24,6 @@ other = "Más"
 
 [Expand-title]
 other = "Expandir..."
+
+[Seen-Mistake-Improve]
+other = "¿Ha visto un error? ¿Quiere mejorar la documentación?"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -24,3 +24,6 @@ other = "Aller plus loin"
 
 [Expand-title]
 other = "Déroulez-moi..."
+
+[Seen-Mistake-Improve]
+other = "Vous avez vu une erreur ? vous voulez améliorer la documentation ?"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -24,3 +24,6 @@ other = "Mais"
 
 [Expand-title]
 other = "Expandir..."
+
+[Seen-Mistake-Improve]
+other = "Viu um erro? quer melhorar a documentação?"

--- a/layouts/partials/git-info.html
+++ b/layouts/partials/git-info.html
@@ -1,31 +1,62 @@
-{{ if .GitInfo }}
-    <div>
-        Last updated on {{ .Lastmod.Format "January 2, 2006" }}
-        {{ with .GitInfo }}:
-            <a href="{{ $.Site.Params.ghCommitURL }}{{ .Hash }}">"{{ .Subject }}" ({{ .AbbreviatedHash }})</a>
+{{ if not (strings.Contains .Site.BaseURL "localhost") }}
+    {{ if .GitInfo }}
+        <div>
+            Last updated on {{ .Lastmod.Format "January 2, 2006" }}
+            {{ with .GitInfo }}:
+                <a href="{{ $.Site.Params.ghCommitURL }}{{ .Hash }}">"{{ .Subject }}" ({{ .AbbreviatedHash }})</a>
+            {{ end }}
+        </div>
+    {{ else }}
+        {{/* 
+            Hugo does not handle git submodules properly for GitInfo.
+            https://github.com/gohugoio/hugo/issues/5533
+            As a very inefective workaround, we parse the Github API to get the last commit of the Page
+        */}}
+        
+        {{ if and (or .IsPage .IsSection) .Site.Params.editURL }}
+            {{- $ghPath := replace .File.Dir "\\" "/" }}
+            {{ if and
+                .Site.Params.versions.current
+                .FirstSection.Params.versionGithubPath
+            }}
+                {{- $pagePathParts := (split (replace .File.Dir "\\" "/") "/") }}
+                {{- $basePath := delimit (after 1 $pagePathParts) "/" }}
+                {{- $ghPath = printf "%s/%s" .FirstSection.Params.versionGithubpath $basePath }}
+                 
+                {{ $githubApiUrl := printf 
+                    "%s?path=%s&sha=%s&page=1&per_page=1" 
+                    .Site.Params.ghApiCommitURL $basePath 
+                    .FirstSection.Params.versionGithubpath 
+                }}
+                
+                <div class="git-info">
+                    {{ $bearer := printf "BEARER %s" (getenv "DEVDOCS_GITHUB_READ_TOKEN") }}
+                    {{ range getJSON $githubApiUrl (dict "Authorization" $bearer) }}
+                        <a href="{{ .html_url }}">
+                            Last updated on {{ .commit.author.date }} by {{ .commit.author.name }}
+                        </a>
+                    {{ end }}
+
+                    <br>{{T "Seen-Mistake-Improve"}}
+
+                    <a class="github-link" 
+                        title='{{T "Improve-this-page"}}' 
+                        href="{{ .Site.Params.editURL }}{{ $ghPath }}{{ .File.LogicalName }}" 
+                        target="blank"
+                    >
+                        <i class="fa fa-pencil"></i>
+                        <span id="top-github-link-text">
+                            {{T "Improve-this-page"}}
+                        </span>
+                    </a>
+                    <a class="how-to-improve" href="{{ .Site.Params.howToContributeURL }}">
+                        <i class="fa fa-question-circle"></i>
+                        <span>
+                            Learn how to contribute
+                        </span>
+                    </a>
+                </div>
+            {{ end }}
         {{ end }}
-    </div>
-{{ else }}
-    {{/* 
-        Hugo does not handle git submodules properly for GitInfo.
-        https://github.com/gohugoio/hugo/issues/5533
-        As a very inefective workaround, we parse the Github API to get the last commit of the Page
-    */}}
-
-    {{ $file := substr .File.Path 2 }}
-    {{ $branch := "8.x" }}
-    
-    {{ if eq (substr .File.Path 0 4) "1.7/" }}
-        {{ $file = substr .File.Path 4 }}
-        {{ $branch = "1.7.x" }}
-    {{ end }}
-    
-    {{ $githubApiUrl := printf "%s?path=%s&sha=%s&page=1&per_page=1" .Site.Params.ghApiCommitURL $file $branch }}
-    {{ $githubFileUrl := printf "%sblob/%s/%s" .Site.Params.ghRepoUrl $branch $file }}
-
-    {{ range getJSON $githubApiUrl }}
-        <a href="{{ $githubFileUrl }}">
-            Last updated on {{ .commit.author.date }} by {{ .commit.author.name }}
-        </a>
     {{ end }}
 {{ end }}

--- a/layouts/partials/git-info.html
+++ b/layouts/partials/git-info.html
@@ -1,8 +1,31 @@
 {{ if .GitInfo }}
-<div>
-  Last updated on {{ .Lastmod.Format "January 2, 2006" }}
-  {{ with .GitInfo }}:
-  <a href="{{ $.Site.Params.ghCommitURL }}{{ .Hash }}">"{{ .Subject }}" ({{ .AbbreviatedHash }})</a>
-  {{ end }}
-</div>
+    <div>
+        Last updated on {{ .Lastmod.Format "January 2, 2006" }}
+        {{ with .GitInfo }}:
+            <a href="{{ $.Site.Params.ghCommitURL }}{{ .Hash }}">"{{ .Subject }}" ({{ .AbbreviatedHash }})</a>
+        {{ end }}
+    </div>
+{{ else }}
+    {{/* 
+        Hugo does not handle git submodules properly for GitInfo.
+        https://github.com/gohugoio/hugo/issues/5533
+        As a very inefective workaround, we parse the Github API to get the last commit of the Page
+    */}}
+
+    {{ $file := substr .File.Path 2 }}
+    {{ $branch := "8.x" }}
+    
+    {{ if eq (substr .File.Path 0 4) "1.7/" }}
+        {{ $file = substr .File.Path 4 }}
+        {{ $branch = "1.7.x" }}
+    {{ end }}
+    
+    {{ $githubApiUrl := printf "%s?path=%s&sha=%s&page=1&per_page=1" .Site.Params.ghApiCommitURL $file $branch }}
+    {{ $githubFileUrl := printf "%sblob/%s/%s" .Site.Params.ghRepoUrl $branch $file }}
+
+    {{ range getJSON $githubApiUrl }}
+        <a href="{{ $githubFileUrl }}">
+            Last updated on {{ .commit.author.date }} by {{ .commit.author.name }}
+        </a>
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Displays git info (author and date) of last commit in footer of pages, by crawling the github API.
| Type?             | new feature

- [x] Got a trouble for now : API requests are limited to 1000/hour/repo, and we have ~2000 pages for now, ~2800 pages soon with all hooks. Must find a way to use tokens to exceed api rate limits ? ✅  Fixed, a token via ENV variable has been added on server. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
