### PR TITLE
Fix hahahugoshortcode-hbhb : Switch to a regex to match s1, s2, s3; ...

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,2 +1,2 @@
-{{ $anchor := replace .Anchor "-hahahugoshortcode-s0-hbhb" ""  }}
+{{ $anchor := replaceRE "-hahahugoshortcode-s(.*)-hbhb" "" .Anchor  }}
 <h{{ .Level }} id="{{ $anchor | safeURL }}">{{ .Text | safeHTML }}<a href="#{{ $anchor | safeHTML }}"></a></h{{ .Level }}>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,8 +1,8 @@
 <div id="toc">
   <div class="wrapper">
     <div id="toc-title">Table of Contents</div>
-    {{ $toc := replace .TableOfContents "HAHAHUGOSHORTCODE-s0-HBHB" "" }}
-    {{ $toc := replace $toc "-hahahugoshortcode-s0-hbhb" "" }}
+    {{ $toc := replaceRE  "HAHAHUGOSHORTCODE-s(.*)-HBHB" "" .TableOfContents }}
+    {{ $toc := replaceRE "-hahahugoshortcode-s(.*)-hbhb" "" $toc }}
     {{ $toc | safeHTML }}
 
     {{ partial "page-nav.html" . }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Was still producing haha when more than 1 shortcode on page (s0, s1, s2, ...)
| Type?             | bug fix 

This is a workaround of Hugo render mecanism for shortcode placeholders, see : https://github.com/gohugoio/hugo/blob/master/hugolib/shortcode.go#L186
