### PR TITLE
Improve homepage of Devdocs and footer with git-info 

### DIFF
--- a/assets/sass/_prestashop.scss
+++ b/assets/sass/_prestashop.scss
@@ -192,14 +192,20 @@ h1 {
 div.mainCategories {
   display: flex;
   flex-wrap: wrap;
+  gap: 2%;
 
   div.mainCategory {
-    flex-basis: 25%;
+    flex-basis: 23%;
 
     div.indexCategory {
       color: #e693b9;
       font-size: 36px;
       margin-bottom: 15px;
+    }
+
+    h3 {
+      padding-bottom: 10px;
+      border-bottom: 3px solid #EEEEEE;
     }
 
     a {
@@ -209,7 +215,7 @@ div.mainCategories {
     ul {
       list-style-type: none;
       padding-left: 0px;
-      min-height: 140px;
+      min-height: 150px;
     }
 
     a.explore-all {
@@ -225,6 +231,8 @@ div.mostViewedPagesIcon {
 }
 h3.mostViewedPagesHeading {
   margin-top: 0px;
+  padding-bottom: 10px;
+  border-bottom: 3px solid #EEEEEE;
 }
 
 div.mostViewedPages {
@@ -246,4 +254,66 @@ div.mostViewedPages {
       background-color: #F8F8F8;
     }
   }
+}
+
+h5.footerHeading {
+  border-bottom: 2px solid #EEEEEE;
+  padding-bottom: 10px;
+}
+
+div.improvedFooter {
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-bottom : 20px;
+
+  div.gitInfo {
+    flex-basis: 20%;
+    font-size: 14px;
+
+    dl {
+      dt {
+        font-weight: normal;
+        float : left;
+        margin-right : 10px;
+      }
+      dd {
+        margin-left: 0px;
+      }
+    }
+  }
+
+  div.contribute {
+    flex-basis: 35%;
+
+    a.github-link {
+      border: 1px solid #df0067;
+      padding : 15px 30px;
+      border-radius: 10px;
+      margin: 10px 0px;
+      color: #df0067;
+      font-size: 14px;
+      background-color: #FDFDFD;
+    }
+
+    a {
+      color: #df0067;
+      font-size: 14px;
+    }
+
+    p {
+      color: #666666;
+    }
+  }
+
+  div.support {
+    flex-basis: 35%;
+
+    a {
+      margin : 10px;
+      font-size: 14px;
+    }
+  }
+  
 }

--- a/assets/sass/_prestashop.scss
+++ b/assets/sass/_prestashop.scss
@@ -188,3 +188,62 @@ h1 {
     @extend .version-pill;
     background-color: #B1AFFF;
 }
+
+div.mainCategories {
+  display: flex;
+  flex-wrap: wrap;
+
+  div.mainCategory {
+    flex-basis: 25%;
+
+    div.indexCategory {
+      color: #e693b9;
+      font-size: 36px;
+      margin-bottom: 15px;
+    }
+
+    a {
+      color: #222222;
+    }
+
+    ul {
+      list-style-type: none;
+      padding-left: 0px;
+      min-height: 140px;
+    }
+
+    a.explore-all {
+      color: #e693b9;
+    }
+  }
+}
+
+div.mostViewedPagesIcon {
+  color: #e693b9;
+  font-size: 36px;
+  margin-top: 20px;
+}
+h3.mostViewedPagesHeading {
+  margin-top: 0px;
+}
+
+div.mostViewedPages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+
+  div.mostViewedPage {
+    flex-basis: 30%;
+    border : 1px solid #EEEEEE;
+    border-radius: 5px;
+    padding: 10px;
+
+    a {
+      color: #222222; 
+    }
+
+    &:hover {
+      background-color: #F8F8F8;
+    }
+  }
+}

--- a/layouts/partials/exploreMostViewedPages.html
+++ b/layouts/partials/exploreMostViewedPages.html
@@ -1,0 +1,16 @@
+{{ if .Page.Param "mostViewedPage" }}
+    <div class="mostViewedPage">
+        {{ if .Page.Param "menuTitle" }}
+            <a href="{{ .Page.RelPermalink }}">
+                {{ .Page.Param "menuTitle" }}
+            </a>
+        {{ else }}
+            <a href="{{ .Page.RelPermalink }}">
+                {{ .Page.Title }}
+            </a>
+        {{ end }}
+    </div>
+{{ end }}
+{{ range .Page.Pages }}
+    {{ partial "exploreMostViewedPages.html" . }}
+{{ end }}

--- a/layouts/partials/git-info.html
+++ b/layouts/partials/git-info.html
@@ -8,57 +8,95 @@
         </div>
     {{ else }}
         {{ if .Site.Params.enableCustomGitInfo }}
-            {{/* 
-                Hugo does not handle git submodules properly for GitInfo.
-                https://github.com/gohugoio/hugo/issues/5533
-                As a very inefective workaround, we parse the Github API to get the last commit of the Page
-            */}}
             
-            {{ if and (or .IsPage .IsSection) .Site.Params.editURL }}
-                {{- $ghPath := replace .File.Dir "\\" "/" }}
-                {{ if and
-                    .Site.Params.versions.current
-                    .FirstSection.Params.versionGithubPath
-                }}
-                    {{- $pagePathParts := (split (replace .File.Dir "\\" "/") "/") }}
-                    {{- $basePath := delimit (after 1 $pagePathParts) "/" }}
-                    {{- $ghPath = printf "%s/%s" .FirstSection.Params.versionGithubpath $basePath }}
-                    
-                    {{ $githubApiUrl := printf 
-                        "%s?path=%s&sha=%s&page=1&per_page=1" 
-                        .Site.Params.ghApiCommitURL $basePath 
-                        .FirstSection.Params.versionGithubpath 
+            <h5 class="footerHeading">Help and support</h5>
+            <div class="improvedFooter">
+
+                {{ if and (or .IsPage .IsSection) .Site.Params.editURL }}
+                    {{- $ghPath := replace .File.Dir "\\" "/" }}
+                    {{ if and
+                        .Site.Params.versions.current
+                        .FirstSection.Params.versionGithubPath
                     }}
-                    
-                    <div class="git-info">
-                        {{ $bearer := printf "BEARER %s" (getenv "DEVDOCS_GITHUB_READ_TOKEN") }}
-                        {{ range getJSON $githubApiUrl (dict "Authorization" $bearer) }}
-                            <a href="{{ .html_url }}">
-                                Last updated on {{ .commit.author.date }} by {{ .commit.author.name }}
+                        {{- $pagePathParts := (split (replace .File.Dir "\\" "/") "/") }}
+                        {{- $basePath := delimit (after 1 $pagePathParts) "/" }}
+                        {{- $ghPath = printf "%s/%s" .FirstSection.Params.versionGithubpath $basePath }}
+
+                        <div class="gitInfo">
+
+                            <h6>Last update</h6>
+                            {{/* 
+                                Hugo does not handle git submodules properly for GitInfo.
+                                https://github.com/gohugoio/hugo/issues/5533
+                                As a very inefective workaround, we parse the Github API to get the last commit of the Page
+                            */}}
+                                    
+                            {{ $githubApiUrl := printf 
+                                "%s?path=%s&sha=%s&page=1&per_page=1" 
+                                .Site.Params.ghApiCommitURL $basePath 
+                                .FirstSection.Params.versionGithubpath 
+                            }}
+                                    
+                            {{ $bearer := printf "BEARER %s" (getenv "DEVDOCS_GITHUB_READ_TOKEN") }}
+                            {{ range getJSON $githubApiUrl (dict "Authorization" $bearer) }}
+                            <dl>
+                                <dt>On</dt>
+                                <dd><a href="{{ .html_url }}">{{ substr .commit.author.date 0 10 }}</a></dd>
+                                <dt>By</dt>
+                                <dd><a href="{{ .html_url }}">{{ .commit.author.name }}</a></dd>
+                            </dl>
+                            {{ end }}
+                               
+                            
+                        </div>
+
+                        <div class="contribute">
+                            <h6>Help us make these docs great!</h6>
+
+                            <p>
+                                All PrestaShop Developer Documentation are open source.  See something that's wrong or unclear? Submit a pull request.
+                            </p>
+
+                            <a class="github-link" 
+                                title='{{T "Improve-this-page"}}' 
+                                href="{{ .Site.Params.editURL }}{{ $ghPath }}{{ .File.LogicalName }}" 
+                                target="blank"
+                            >
+                                <i class="fa fa-github"></i>
+                                <span id="top-github-link-text">
+                                    {{T "Improve-this-page"}}
+                                </span>
                             </a>
-                        {{ end }}
 
-                        <br>{{T "Seen-Mistake-Improve"}}
+                            <br>
 
-                        <a class="github-link" 
-                            title='{{T "Improve-this-page"}}' 
-                            href="{{ .Site.Params.editURL }}{{ $ghPath }}{{ .File.LogicalName }}" 
-                            target="blank"
-                        >
-                            <i class="fa fa-pencil"></i>
-                            <span id="top-github-link-text">
-                                {{T "Improve-this-page"}}
-                            </span>
-                        </a>
-                        <a class="how-to-improve" href="{{ .Site.Params.howToContributeURL }}">
-                            <i class="fa fa-question-circle"></i>
-                            <span>
-                                Learn how to contribute
-                            </span>
-                        </a>
-                    </div>
+                            <a class="how-to-improve" href="{{ .Site.Params.howToContributeURL }}">
+                                <span>
+                                    Learn how to contribute
+                                </span>
+                            </a>
+                        </div>
+
+                        <div class="support">
+                            <h6>Still need help ?</h6>
+
+                            <a href="https://www.prestashop-project.org/slack/">
+                                <i class="fa fa-slack"></i> Join the PrestaShop Project’s Slack Chat
+                            </a>
+                            <a href="https://github.com/PrestaShop/PrestaShop/discussions">
+                                <i class="fa fa-github"></i> Join us on Github Discussions
+                            </a>                            
+                            <a href="https://www.prestashop.com/en/support">
+                                <i class="fa fa-question-circle"></i> Find support on Prestashop.com
+                            </a>
+                            <a href="https://build.prestashop-project.org/">
+                                <i class="fa fa-newspaper-o"></i> Discover our developer's blog
+                            </a>
+                        </div>
+
+                    {{ end }}
                 {{ end }}
-            {{ end }}
+            </div>
         {{ end }}
     {{ end }}
 {{ end }}

--- a/layouts/shortcodes/mainCategories.html
+++ b/layouts/shortcodes/mainCategories.html
@@ -3,7 +3,7 @@
 <div class="mainCategories">
 {{ with .Site.GetPage $currentSection }}
     {{ range .Page.Pages }}
-        {{ if .Param "featured" }}
+        {{ if .Param "showOnHomepage" }}
         <div class="mainCategory">
             <h3>
                 <div class="indexCategory">
@@ -25,7 +25,7 @@
             </h3>
             <ul>
                 {{ range .Page.Pages }}
-                    {{ if .Param "featured" }}
+                    {{ if .Param "showOnHomepage" }}
                         <li>
                             {{ if .Param "menuTitle" }}
                                 <a href="{{ .RelPermalink }}">

--- a/layouts/shortcodes/mainCategories.html
+++ b/layouts/shortcodes/mainCategories.html
@@ -1,0 +1,57 @@
+{{ $currentSection := .Site.Params.versions.current }}
+
+<div class="mainCategories">
+{{ with .Site.GetPage $currentSection }}
+    {{ range .Page.Pages }}
+        {{ if .Param "featured" }}
+        <div class="mainCategory">
+            <h3>
+                <div class="indexCategory">
+                    {{ if .Param "icon" }}
+                        <i class="fa {{ .Param "icon" }}"></i>
+                    {{ else}}
+                        <i class="fa fa-star"></i>
+                    {{ end}}
+                </div>
+                {{ if .Param "menuTitle" }}
+                    <a href="{{ .RelPermalink }}">
+                        {{ .Param "menuTitle" }}
+                    </a>
+                {{ else }}
+                    <a href="{{ .RelPermalink }}">
+                        {{ .Title }}
+                    </a>
+                {{ end }}
+            </h3>
+            <ul>
+                {{ range .Page.Pages }}
+                    {{ if .Param "featured" }}
+                        <li>
+                            {{ if .Param "menuTitle" }}
+                                <a href="{{ .RelPermalink }}">
+                                    {{ .Param "menuTitle" }}
+                                </a>
+                            {{ else }}
+                                <a href="{{ .RelPermalink }}">
+                                    {{ .Title }}
+                                </a>
+                            {{ end }}
+                        </li>
+                    {{ end }}
+                {{ end }}
+            </ul>
+            <a href="{{ .RelPermalink }}" class="explore-all">
+                <i class="fa fa-arrow-right"></i> 
+                All 
+                {{ if .Param "menuTitle" }}
+                    {{ .Param "menuTitle" }} 
+                {{ else }}
+                    {{ .Title }} 
+                {{ end }}
+                topics
+            </a>
+        </div>
+        {{ end }}
+    {{ end }}
+{{ end }}
+</div>

--- a/layouts/shortcodes/mostViewedPages.html
+++ b/layouts/shortcodes/mostViewedPages.html
@@ -1,0 +1,14 @@
+{{ $currentSection := .Site.Params.versions.current }}
+
+<div class="mostViewedPagesIcon">
+    <i class="fa fa-star"></i>
+</div>
+<h3 class="mostViewedPagesHeading">
+    Most viewed pages
+</h3>
+
+<div class="mostViewedPages">
+    {{ with .Site.GetPage $currentSection }}
+        {{ partial "exploreMostViewedPages.html" . }}
+    {{ end }}
+</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Improvement of the homepage and footer to improve user experience

Related to : https://github.com/PrestaShop/docs/pull/1652
Related to : https://github.com/PrestaShop/devdocs-site/pull/23

![Screenshot 2023-04-25 at 18 36 59](https://user-images.githubusercontent.com/1589947/234348868-92d654e8-0af9-4bdd-9347-e64e166dafb4.png)

![Screenshot 2023-04-25 at 18 36 21](https://user-images.githubusercontent.com/1589947/234348889-a218902f-df6b-4068-b73f-83f2f77deb0b.png)

Can be merged independently
