### PR TITLE
Better version selector : Loop on parents of page if non existent on target version while a matching parent is found

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -174,6 +174,12 @@
     {{ $currentPage := .File.Path }}
     {{- $pagePathParts := (split $currentPage "/") }}
     {{- $basePath := delimit (after 1 $pagePathParts) "/" }}
+
+    {{ $targetParts := after 1 $pagePathParts }}
+    {{ $targetPartsCount := len $targetParts }}
+
+    {{ $globalPage := . }}
+    
     <div class="version-selector-container">
       <div class="version-selector" aria-label="Documentation version">
         <div class="version-selector-current">
@@ -189,13 +195,19 @@
         <ul class="version-selector-dropdown">
           {{ range .Site.Home.Sections -}}
             <li>
-              {{- $canonicalPath := printf "%s/%s" .Params.versionId $basePath }}
+              {{ $targetVersionId := .Params.versionId }}
               {{- $canonicalPage := "" }}
-              {{- with .Site.GetPage $canonicalPath -}}
-                  {{ $canonicalPage = . }}
-              {{- end }}
-              {{- $currentVersionPage := .Site.GetPage (printf "/%s" .Site.Params.versions.current) }}
-              
+              {{ range (seq 0 (sub $targetPartsCount 1)) }}
+                {{ $path := (delimit (first (sub $targetPartsCount .) $targetParts) "/") }}
+                {{ $canonicalPath := printf "%s/%s" $targetVersionId $path }}
+            
+                {{ with $globalPage.Site.GetPage $canonicalPath }}
+                  {{ if and (ne . "") (eq $canonicalPage "") }}
+                    {{ $canonicalPage = . }}
+                  {{ end }}  
+                {{ end }}
+              {{ end }}
+                                
               {{- if ne $canonicalPage "" }}
                 <a href="{{ $canonicalPage.RelPermalink }}">
               {{- else }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Loop on parents of page if non existent on target version while a matching parent is found
| Type?             | improvement
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/docs/issues/1635
