### PR TITLE
Add shortcode to retrieve markdown files content from github API

### DIFF
--- a/layouts/shortcodes/remoteMd.html
+++ b/layouts/shortcodes/remoteMd.html
@@ -1,0 +1,5 @@
+{{- $remote_url := (.Get 0) -}}
+{{- $remote_data := getJSON $remote_url -}}
+{{- with $remote_data -}}
+    {{ $remote_data.content | base64Decode | safeHTML }}
+{{- end -}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Allows to retrieve a JSON from the github API, decode its content, and display it
