### PR TITLE
Add swagger layout to display swagger documentation page

### DIFF
--- a/layouts/_default/swagger.html
+++ b/layouts/_default/swagger.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="SwaggerUI" />
+    <title>SwaggerUI</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+<script>
+    window.onload = () => {
+        window.ui = SwaggerUIBundle({
+            url: '{{ .Params.openApiUrl }}',
+            dom_id: '#swagger-ui',
+        });
+    };
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add swagger layout to display swagger documentation page
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/36928
| Sponsor company   | ~
| How to test?      | ~

This layout can be used with a page defined this way:

```markdown
---
title: Swagger Documentation
menuTitle: Swagger Documentation
layout: swagger
openApiUrl: ./openapi.json
---
```

The `openApiUrl` parameter is injected in the layout and then Swagger does the rest